### PR TITLE
Don't listen to Git events when the Git Integration is disabled

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -63,6 +63,10 @@ class ServiceProvider extends AddonServiceProvider
 
     private function bootListeners()
     {
+        if (! config('statamic.git.enabled')) {
+            return;
+        }
+        
         \Statamic\Facades\Git::listen(TranslationsSaved::class);
 
     }


### PR DESCRIPTION
This pull request fixes an issue where an exception would be thrown when using this addon on an environment with the Git Integration disabled.

https://github.com/statamic/cms/blob/fbd53fb8d7224de7716954fa0710be8cb1d9c2ec/src/Git/Git.php#L19-L21

Exception: https://flareapp.io/share/LPlKvyQm

Discord conversation: https://discord.com/channels/489818810157891584/489818810157891586/1177218270407958568