### PR TITLE
Allow empty translations when saving on the CP.

### DIFF
--- a/src/TranslationsManager.php
+++ b/src/TranslationsManager.php
@@ -160,7 +160,7 @@ class TranslationsManager
     {
         foreach ($translations as $namespace => $phrases) {
             $phrases = collect($phrases)
-                ->mapWithKeys(fn ($phrase) => [$phrase['key'] => $phrase['string']]);
+                ->mapWithKeys(fn ($phrase) => [$phrase['key'] => $phrase['string'] ?? '']);
 
             $phrasesToPreventUndotting = $phrases->filter($this->ignoreUndottingFilter);
 


### PR DESCRIPTION
When saving translations on the Control Panel, if a translation is empty, an error is shown.

![image](https://github.com/ryanmitchell/statamic-translation-manager/assets/1935397/08c39d25-4d8e-4404-ad27-5b35b9234bcb)


This fixes it and allows to save empty translations, so the user don't have to do all of them in one go.