### PR TITLE
Add the ability to parse antlers trans modifier.

### DIFF
--- a/src/Extractor/AntlersParser.php
+++ b/src/Extractor/AntlersParser.php
@@ -15,6 +15,10 @@ class AntlersParser
         'trans',
     ];
 
+    private $antlersTranslationModifiers = [
+        'trans',
+    ];
+
     public function __construct()
     {
         $this->documentParser = new DocumentParser();
@@ -56,6 +60,23 @@ class AntlersParser
                     }
 
                     $keys[] = $keyParam->value;
+                }
+            }
+
+            if ($node->runtimeNodes) {
+                $nodes = collect($node->runtimeNodes);
+                $hasTranslationModifier = $nodes
+                    ->filter(fn ($node) => get_class($node) == \Statamic\View\Antlers\Language\Nodes\ModifierNameNode::class && in_array($node->name, $this->antlersTranslationModifiers))
+                    ->first();
+
+                if ($hasTranslationModifier) {
+                    $translation = $nodes
+                        ->filter(fn ($node) => get_class($node) == \Statamic\View\Antlers\Language\Nodes\StringValueNode::class)
+                        ->first();
+
+                    if ($translation) {
+                        $keys[] = $translation->value;
+                    }
                 }
             }
         }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -57,4 +57,9 @@ class TestCase extends OrchestraTestCase
 
         $app->useLangPath(__DIR__.'/__fixtures');
     }
+
+    protected function getSampleFilePath($file)
+    {
+        return realpath(dirname(__FILE__)."/samples/{$file}");
+    }
 }

--- a/tests/Unit/Extractor/AntlersParserTest.php
+++ b/tests/Unit/Extractor/AntlersParserTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace RyanMitchell\StatamicTranslationManager\Tests\Unit\Extractor;
+
+use RyanMitchell\StatamicTranslationManager\Tests\TestCase;
+use RyanMitchell\StatamicTranslationManager\Extractor\AntlersParser;
+
+class AntlersParserTest extends TestCase
+{
+    /** @test */
+    public function it_can_parse_trans_modifier_from_antlers_file()
+    {
+        $parser = new AntlersParser;
+
+        $keys = $parser->parse($this->getSampleFilePath('trans_modifier.antlers.html'));
+
+        $this->assertEquals([
+            'Translation using modifier'
+        ], $keys);
+    }
+
+    /** @test */
+    public function it_can_parse_trans_tag_from_antlers_file()
+    {
+        $parser = new AntlersParser;
+
+        $keys = $parser->parse($this->getSampleFilePath('trans_tag.antlers.html'));
+
+        $this->assertEquals([
+            'Translation using tag'
+        ], $keys);
+    }
+}

--- a/tests/samples/trans_modifier.antlers.html
+++ b/tests/samples/trans_modifier.antlers.html
@@ -1,0 +1,3 @@
+<main>
+    <h1>{{ "Translation using modifier" | trans }}</h1>
+</main>

--- a/tests/samples/trans_tag.antlers.html
+++ b/tests/samples/trans_tag.antlers.html
@@ -1,0 +1,3 @@
+<main>
+    <h1>{{ trans key="Translation using tag" }}</h1>
+</main>


### PR DESCRIPTION
When scanning the templates for translations, now it will also parse the "trans" modifier (https://statamic.dev/modifiers/trans). Example:

```
{{ "Hello" | trans }}
```
