### PR TITLE
Fix "Undefined array key 0" error in AntlersParser

### DIFF
--- a/src/Extractor/AntlersParser.php
+++ b/src/Extractor/AntlersParser.php
@@ -88,7 +88,9 @@ class AntlersParser
     {
         foreach ($rootNode->processedInterpolationRegions as $interpolationRegion) {
             /** @var AntlersNode $node */
-            $node = $interpolationRegion[0];
+            if (isset($interpolationRegion[0])) {
+                $node = $interpolationRegion[0];
+            }
 
             if (! empty($node->processedInterpolationRegions)) {
                 $foundKeys = array_merge($foundKeys, $this->locateInterpolatedTranslationKeys($node, $foundKeys));


### PR DESCRIPTION
Added a conditional check before accessing the first element of $interpolationRegion to prevent an "Undefined array key 0" error when scanning templates.

I couldn't pass the tests unfortunately. I tried `composer install`, but got this error:
- Required package "brick/varexporter" is in the lock file as "0.4.0" but that does not satisfy your constraint "^0.5".
This usually happens when composer files are incorrectly merged or the composer.json file is manually edited.

I then tried `composer update`, and that installed the packages, but the tests wouldn't pass since composer updated statamic, which removes the config/sites.php file, is my guess.