### PR TITLE
Fix boot order

### DIFF
--- a/resources/lang/de/default.php
+++ b/resources/lang/de/default.php
@@ -1,12 +1,12 @@
 <?php
 
   return [
-    "add_to_pack" => "Add To Language Pack",
+    "add_to_pack" => "Zu Sprachpaket hinzufügen",
     "blueprint_scan" => "Blueprint-Scan",
     "check_for_missing_translations" => "Fehlende Übersetzungen prüfen",
     "manage_translations" => "Übersetzungen verwalten",
     "manage_translation_locale" => "Übersetzung verwalten für: :locale",
-    "missing_translations" => ":count missing translation|:count missing translations",
+    "missing_translations" => ":count fehlende Übersetzung|:count fehlende Übersetzungen",
     "no_missing_translations" => "Keine fehlenden Übersetzungen. Tolle Arbeit!",
     "scan_blueprints" => "Blueprints durchsuchen",
     "scan_blueprints_desc" => "Durchsuche Blueprints auf fehlende Strings und füge sie deinen Sprach-Dateien hinzu.",
@@ -18,4 +18,3 @@
     "translation_manager" => "Übersetzungs-Manager",
     "translations_added" => "Übersetzungen hinzugefügt. Fehlende Übersetzungen sind leere Felder."
 ];
-

--- a/resources/lang/de/default.php
+++ b/resources/lang/de/default.php
@@ -13,7 +13,6 @@
     "scan_templates" => "Templates durchsuchen",
     "scan_templates_desc" => "Durchsuche Templates auf fehlende Strings in `{ trans }` Tags und füge sie deinen Sprach-Dateien hinzu.",
     "template_scan" => "Template-Scan",
-    "tools" => "Werkzeuge",
     "translations" => "Übersetzungen",
     "translation_manager" => "Übersetzungs-Manager",
     "translations_added" => "Übersetzungen hinzugefügt. Fehlende Übersetzungen sind leere Felder."

--- a/resources/lang/de_CH/default.php
+++ b/resources/lang/de_CH/default.php
@@ -13,7 +13,6 @@
     "scan_templates" => "Templates durchsuchen",
     "scan_templates_desc" => "Durchsuche Templates auf fehlende Strings in `{ trans }` Tags und füge sie deinen Sprach-Dateien hinzu.",
     "template_scan" => "Template-Scan",
-    "tools" => "Werkzeuge",
     "translations" => "Übersetzungen",
     "translation_manager" => "Übersetzungs-Manager",
     "translations_added" => "Übersetzungen hinzugefügt. Fehlende Übersetzungen sind leere Felder."

--- a/resources/lang/de_CH/default.php
+++ b/resources/lang/de_CH/default.php
@@ -1,0 +1,20 @@
+<?php
+
+  return [
+    "add_to_pack" => "Zu Sprachpaket hinzufügen",
+    "blueprint_scan" => "Blueprint-Scan",
+    "check_for_missing_translations" => "Fehlende Übersetzungen prüfen",
+    "manage_translations" => "Übersetzungen verwalten",
+    "manage_translation_locale" => "Übersetzung verwalten für: :locale",
+    "missing_translations" => ":count fehlende Übersetzung|:count fehlende Übersetzungen",
+    "no_missing_translations" => "Keine fehlenden Übersetzungen. Tolle Arbeit!",
+    "scan_blueprints" => "Blueprints durchsuchen",
+    "scan_blueprints_desc" => "Durchsuche Blueprints auf fehlende Strings und füge sie deinen Sprach-Dateien hinzu.",
+    "scan_templates" => "Templates durchsuchen",
+    "scan_templates_desc" => "Durchsuche Templates auf fehlende Strings in `{ trans }` Tags und füge sie deinen Sprach-Dateien hinzu.",
+    "template_scan" => "Template-Scan",
+    "tools" => "Werkzeuge",
+    "translations" => "Übersetzungen",
+    "translation_manager" => "Übersetzungs-Manager",
+    "translations_added" => "Übersetzungen hinzugefügt. Fehlende Übersetzungen sind leere Felder."
+];

--- a/resources/lang/en/default.php
+++ b/resources/lang/en/default.php
@@ -13,9 +13,7 @@
     "scan_templates" => "Scan templates",
     "scan_templates_desc" => "Scan your templates for missing strings in { trans } tags and add them to your language packs",
     "template_scan" => "Template Scan",
-    "tools" => "Tools",
     "translations" => "Translations",
     "translation_manager" => "Translation Manager",
     "translations_added" => "Translations added. Look for blank strings"
 ];
-

--- a/resources/lang/fr/default.php
+++ b/resources/lang/fr/default.php
@@ -13,9 +13,7 @@
     "scan_templates" => "Scan des modèles (templates)",
     "scan_templates_desc" => "Scannez vos modèles (templates) à la recherche de chaînes manquantes dans les balises { trans } et ajoutez-les à vos packs de langue.",
     "template_scan" => "Scan des Templates",
-    "tools" => "Outils",
     "translations" => "Traductions",
     "translation_manager" => "Gestionnaire de traductions",
     "translations_added" => "Traductions ajoutées. Recherchez des chaînes vides."
 ];
-

--- a/resources/lang/nl/default.php
+++ b/resources/lang/nl/default.php
@@ -13,9 +13,7 @@
     "scan_templates" => "Scan templates",
     "scan_templates_desc" => "Scan templates op missende strings in `{ trans }` tags en voeg ze toe aan je taalbestanden.",
     "template_scan" => "Templatescan",
-    "tools" => "Gereedschappen",
     "translations" => "Vertalingen",
     "translation_manager" => "Vertalingsmanager",
     "translations_added" => "Vertalingen toegevoegd. Nieuwe vertalingen zijn standaard lege strings."
 ];
-

--- a/resources/lang/nl/nl.json
+++ b/resources/lang/nl/nl.json
@@ -10,7 +10,6 @@
     "Scan your blueprints for missing strings and add them to your language packs": "Scan blueprints op missende strings en voeg ze toe aan je taalbestanden.",
     "Scan your templates for missing strings in { trans } tags and add them to your language packs": "Scan templates op missende strings in `{ trans }` tags en voeg ze toe aan je taalbestanden.",
     "Template Scan": "Templatescan",
-    "Tools": "Gereedschappen",
     "Translations": "Vertalingen",
     "Translation Manager": "Vertalingsmanager",
     "Translations added. Look for blank strings": "Vertalingen toegevoegd. Nieuwe vertalingen zijn standaard lege strings."

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -46,7 +46,7 @@ class ServiceProvider extends AddonServiceProvider
     {
         NavAPI::extend(fn (Nav $nav) => $nav
             ->content(__('statamic-translation-manager::default.translations'))
-            ->section(__('statamic-translation-manager::default.tools'))
+            ->section('Tools')
             ->can('manage translations')
             ->route('translation-manager.index')
             ->icon('content-writing')

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -13,10 +13,8 @@ use Statamic\Statamic;
 
 class ServiceProvider extends AddonServiceProvider
 {
-    public function boot()
+    public function bootAddon()
     {
-        parent::boot();
-
         $this->loadViewsFrom(__DIR__.'/../resources/views', 'statamic-translation-manager');
 
         $this->publishes([


### PR DESCRIPTION
- Fix boot order to ensure Statamic sets locales before translating
- Move translations tool to `Tools` section in the CP navigation
- Add missing translations for `de`
- Provide translations for `de_CH`