### PR TITLE
Update Card class to include flex-wrap

### DIFF
--- a/resources/js/pages/Index.vue
+++ b/resources/js/pages/Index.vue
@@ -25,7 +25,7 @@ defineProps([
     <Header :title="__('statamic-translation-manager::default.translation_manager')" icon="dictionary-language-book"/>
 
     <Panel :heading="__('statamic-translation-manager::default.manage_translations')">
-        <Card class="flex gap-4">
+        <Card class="flex flex-wrap gap-4">
             <Button class="m-0" v-for="locale in locales" :href="cp_url(`/translations/locale/${locale.name}/edit`)" :text="locale.name" />
         </Card>
     </Panel>


### PR DESCRIPTION
When you have a lot of translations the locales list overflows:

<img width="951" height="539" alt="Screenshot 2026-03-15 at 17 29 18" src="https://github.com/user-attachments/assets/4ec318dd-a596-4f92-bf31-a174ec6af01c" />

**With wrap:**

<img width="949" height="624" alt="Screenshot 2026-03-15 at 17 29 06" src="https://github.com/user-attachments/assets/9bcb6a32-27a2-4f86-84fb-49461bb6678e" />
